### PR TITLE
Добавлена ручная сортировка на экране Избранное

### DIFF
--- a/lib/data/memory_favorites_provider.dart
+++ b/lib/data/memory_favorites_provider.dart
@@ -8,7 +8,6 @@ import 'package:places/mocks.dart';
 /// Менеджер списка Избранное на моковых данных.
 class MemoryFavoritesProvider extends ChangeNotifier
     implements FavoritesProvider {
-
   @override
   Future<Iterable<Sight>> items() async =>
       UnmodifiableListView(mocks.where((element) => element.isLiked));
@@ -21,6 +20,28 @@ class MemoryFavoritesProvider extends ChangeNotifier
   @override
   Future<void> remove(Sight value) async {
     _manage(value.id, false);
+  }
+
+  @override
+  Future<void> reorder({required String sourceId, String? insertBeforeId}) async {
+    final sourceIndex = mocks.indexWhere((element) => element.id == sourceId);
+    final targetIndex = insertBeforeId != null
+        ? mocks.indexWhere((element) => element.id == insertBeforeId)
+        : null;
+    assert(sourceIndex >= 0 || (targetIndex ?? 0) >= 0);
+
+    if (sourceIndex >= 0 && sourceIndex != targetIndex) {
+      final sight = mocks.removeAt(sourceIndex);
+      if (targetIndex == null) {
+        mocks.add(sight);
+        notifyListeners();
+      } else {
+        if (targetIndex >= 0) {
+          mocks.insert(targetIndex, sight);
+          notifyListeners();
+        }
+      }
+    }
   }
 
   void _manage(String id, bool isLiked) {

--- a/lib/domain/favorites_provider.dart
+++ b/lib/domain/favorites_provider.dart
@@ -13,4 +13,8 @@ abstract class FavoritesProvider implements Listenable {
   Future<void> add(Sight value);
 
   Future<void> remove(Sight value);
+
+  /// Перемещает элемент с id=[sourceId] в позицию перед элементом с id=[insertBeforeId].
+  /// Если [insertBeforeId] не указан, перемещает в конец списка.
+  Future<void> reorder({required String sourceId, String? insertBeforeId});
 }

--- a/lib/ui/const/app_strings.dart
+++ b/lib/ui/const/app_strings.dart
@@ -31,6 +31,7 @@ abstract class AppStrings {
   static const save = 'СОХРАНИТЬ';
   static const newSight = 'НОВОЕ МЕСТО';
   static const clearHistory = 'Очистить историю';
+  static const delete = 'Удалить';
 
   // Категории
   static const hotel = 'Отель';

--- a/lib/ui/screen/res/theme_extension.dart
+++ b/lib/ui/screen/res/theme_extension.dart
@@ -79,6 +79,11 @@ extension ThemeExtension on ThemeData {
         color: colorScheme.inactiveBlack,
       );
 
+  TextStyle get superSmall500White => textTheme.superSmall.copyWith(
+    color: colorScheme.white,
+    fontWeight: FontWeight.w500,
+  );
+
   // ----- Экран "Детализация" -----
 
   TextStyle get smallBoldForDetailsType => textTheme.smallBold.copyWith(

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
+import 'package:places/ui/const/app_icons.dart';
+import 'package:places/ui/const/app_strings.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_details.dart';
+import 'package:places/ui/widget/controls/spacers.dart';
+import 'package:places/ui/widget/controls/svg_icon.dart';
 import 'package:places/ui/widget/sight_card_image.dart';
 import 'package:places/ui/widget/sight_card_text.dart';
 
@@ -9,18 +13,21 @@ import 'package:places/ui/widget/sight_card_text.dart';
 class SightCard extends StatelessWidget {
   final Sight sight;
   final CardMode mode;
-  final bool draggable;
 
   const SightCard({
     Key? key,
     required this.sight,
     required this.mode,
-    this.draggable = false,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final draggable = mode == CardMode.favorites;
+    final dismissible = draggable;
+
     Widget card = Card(
+      margin: EdgeInsets.zero,
       child: InkWell(
         onTap: () {
           context.pushScreen<SightDetails>(
@@ -61,6 +68,39 @@ class SightCard extends StatelessWidget {
             child: Opacity(opacity: 0.8, child: card),
           ),
         ),
+      );
+    }
+
+    if (dismissible) {
+      card = Stack(
+        alignment: Alignment.centerRight,
+        children: [
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.error,
+                borderRadius: const BorderRadius.all(Radius.circular(12.0)),
+              ),
+            ),
+          ),
+          Positioned(
+            right: 16.0,
+            child: Column(
+              children: [
+                const SvgIcon(AppIcons.bucket),
+                spacerH8,
+                Text(AppStrings.delete, style: theme.superSmall500White),
+              ],
+            ),
+          ),
+          Dismissible(
+            child: card,
+            key: ValueKey('dm_${sight.id}'),
+            direction: DismissDirection.endToStart,
+            onDismissed: (_) =>
+                SightCardImage.toggleInFavorites(context, sight),
+          ),
+        ],
       );
     }
 

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -8,18 +8,19 @@ import 'package:places/ui/widget/sight_card_text.dart';
 /// Виджет карточки места.
 class SightCard extends StatelessWidget {
   final Sight sight;
-
   final CardMode mode;
+  final bool draggable;
 
   const SightCard({
     Key? key,
     required this.sight,
     required this.mode,
+    this.draggable = false,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    Widget card = Card(
       child: InkWell(
         onTap: () {
           context.pushScreen<SightDetails>(
@@ -44,6 +45,26 @@ class SightCard extends StatelessWidget {
         ),
       ),
     );
+
+    if (draggable) {
+      card = LongPressDraggable<String>(
+        child: card,
+        data: sight.id,
+        axis: Axis.vertical,
+        childWhenDragging: const SizedBox(),
+        feedback: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width - 16.0 * 2,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Opacity(opacity: 0.8, child: card),
+          ),
+        ),
+      );
+    }
+
+    return card;
   }
 }
 

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -51,6 +51,8 @@ class VisitingScreen extends StatelessWidget {
                         details: AppStrings.tagPlaces,
                       ),
                       mode: CardMode.favorites,
+                      onOrderChanged: (sourceId, insertAfterId) =>
+                          _onDragComplete(context, sourceId, insertAfterId),
                     ),
                     SightList(
                       sights: data.where((sight) => sight.isVisited),
@@ -60,6 +62,8 @@ class VisitingScreen extends StatelessWidget {
                         details: AppStrings.finishRoute,
                       ),
                       mode: CardMode.favorites,
+                      onOrderChanged: (sourceId, insertAfterId) =>
+                          _onDragComplete(context, sourceId, insertAfterId),
                     ),
                   ],
                 );
@@ -68,6 +72,18 @@ class VisitingScreen extends StatelessWidget {
           },
         ),
       ),
+    );
+  }
+
+  Future<void> _onDragComplete(
+    BuildContext context,
+    String sourceId,
+    String? insertAfterId,
+  ) async {
+    final favoritesProvider = Favorites.of(context)!;
+    await favoritesProvider.reorder(
+      sourceId: sourceId,
+      insertBeforeId: insertAfterId,
     );
   }
 }

--- a/lib/ui/widget/sight_card_image.dart
+++ b/lib/ui/widget/sight_card_image.dart
@@ -66,7 +66,7 @@ class SightCardImage extends StatelessWidget {
                         ? AppIcons.close
                         : AppIcons.heartFilled)
                     : AppIcons.heart,
-                onPressed: () => _toggleInFavorites(context),
+                onPressed: () => toggleInFavorites(context, sight),
               ),
             ],
           ),
@@ -75,7 +75,7 @@ class SightCardImage extends StatelessWidget {
     );
   }
 
-  Future<void> _toggleInFavorites(BuildContext context) async {
+  static Future<void> toggleInFavorites(BuildContext context, Sight sight) async {
     final favoritesProvider = Favorites.of(context)!;
     sight.isLiked
         ? await favoritesProvider.remove(sight)

--- a/lib/ui/widget/sight_list.dart
+++ b/lib/ui/widget/sight_list.dart
@@ -1,41 +1,120 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
+import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_card.dart';
+import 'package:places/ui/screen/sight_list_screen.dart';
+import 'package:places/ui/screen/visiting_screen.dart';
+import 'package:places/ui/widget/controls/spacers.dart';
 
+/// Виджет для отображения списка карточек мест.
+///
+/// Используется на экранах [SightListScreen] и [VisitingScreen].
 class SightList extends StatelessWidget {
+  /// Список элементов для отображения.
   final Iterable<Sight> sights;
+
+  /// Виджет, отображаемый в случае пустого списка элементов.
   final Widget empty;
+
+  /// Режим отображения [CardMode] карточки места.
+  ///
+  /// Карточка одного и того же места может отображаться по-разному,
+  /// в зависимости от того, на каком экране она находится.
   final CardMode mode;
+
+  /// Callback на перемещение карточки.
+  final OnOrderChanged? onOrderChanged;
 
   const SightList({
     Key? key,
     required this.sights,
     required this.empty,
     required this.mode,
+    this.onOrderChanged,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final draggable = onOrderChanged != null && sights.length > 1;
+
     return sights.isEmpty
         ? empty
         : SingleChildScrollView(
-          child: Column(
-              children: sights
-                  .map(
-                    (sight) => Padding(
-                      key: ValueKey(sight.id),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16.0,
-                        vertical: 8.0,
-                      ),
-                      child: SightCard(
+            dragStartBehavior: DragStartBehavior.down,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ...sights.expand(
+                    (sight) => [
+                      if (draggable)
+                        _DragTargetSpacer(
+                          id: sight.id,
+                          onOrderChanged: onOrderChanged,
+                        )
+                      else
+                        spacerH24,
+                      SightCard(
+                        key: ValueKey(sight.id),
                         sight: sight,
                         mode: mode,
+                        draggable: draggable,
                       ),
-                    ),
-                  )
-                  .toList(growable: false),
+                    ],
+                  ),
+                  if (draggable)
+                    _DragTargetSpacer(
+                      id: null,
+                      onOrderChanged: onOrderChanged,
+                    )
+                  else
+                    spacerH24,
+                ],
+              ),
             ),
-        );
+          );
   }
 }
+
+/// Разделитель, выступающий в роли приемника карточек при ручной сортировке.
+class _DragTargetSpacer extends StatelessWidget {
+  final String? id;
+  final OnOrderChanged? onOrderChanged;
+
+  const _DragTargetSpacer({Key? key, required this.id, this.onOrderChanged})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<String>(
+      onWillAccept: (value) {
+        return value != id;
+      },
+      onAccept: _onDragComplete,
+      builder: (context, candidateData, rejectedData) {
+        return SizedBox(
+          height: 24.0,
+          child: candidateData.isNotEmpty
+              ? Divider(
+                  color: Theme.of(context).colorScheme.green,
+                  thickness: 4.0,
+                )
+              : null,
+        );
+      },
+    );
+  }
+
+  void _onDragComplete(String sourceId) {
+    if (onOrderChanged != null) {
+      onOrderChanged!(sourceId, id);
+    }
+  }
+}
+
+typedef OnOrderChanged = void Function(
+  String sourceId,
+  String? insertAfterId,
+);

--- a/lib/ui/widget/sight_list.dart
+++ b/lib/ui/widget/sight_list.dart
@@ -60,7 +60,6 @@ class SightList extends StatelessWidget {
                         key: ValueKey(sight.id),
                         sight: sight,
                         mode: mode,
-                        draggable: draggable,
                       ),
                     ],
                   ),


### PR DESCRIPTION
Сохранение порядка сортировки реализовано через FavoritesProvider. Т.к. карточки из "Хочу посетить" и "Уже посетил" не пересекаются, то сквозная сортировка всех "избранных" не вызовет проблем.
В текущей реализации хранения порядка сортировки есть побочный эффект - меняется порядок на экране "Список мест", но т.к. это временное решение - не стал усложнять код.

https://user-images.githubusercontent.com/89590481/158034152-3ac56567-eda4-4969-b1d0-9bcaff1a318d.mp4
