### PR TITLE
Замена SingleChildScrollView на ListView

### DIFF
--- a/lib/ui/const/platform.dart
+++ b/lib/ui/const/platform.dart
@@ -1,7 +1,0 @@
-import 'dart:io';
-
-import 'package:flutter/cupertino.dart';
-
-final platformScrollPhysics = Platform.isIOS
-    ? const BouncingScrollPhysics()
-    : const ClampingScrollPhysics();

--- a/lib/ui/const/platform.dart
+++ b/lib/ui/const/platform.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+
+final platformScrollPhysics = Platform.isIOS
+    ? const BouncingScrollPhysics()
+    : const ClampingScrollPhysics();

--- a/lib/ui/screen/filters_screen.dart
+++ b/lib/ui/screen/filters_screen.dart
@@ -67,11 +67,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               style: theme.superSmallInactiveBlack,
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8.0),
-            child: CategoriesGrid(
-              checked: categories,
-              onCategoryPressed: _onCategoriesChange,
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: CategoriesGrid(
+                checked: categories,
+                onCategoryPressed: _onCategoriesChange,
+              ),
             ),
           ),
           spacerH8,
@@ -79,18 +81,17 @@ class _FiltersScreenState extends State<FiltersScreen> {
             range: distance,
             onChanged: _onDistanceChange,
           ),
-          const Expanded(child: SizedBox()),
-          Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child: ElevatedButton(
-              onPressed: filter.isNotEmpty ? _onApplyFilter : null,
-              child: Text(
-                AppStrings.showFilterResults(filter.length),
-              ),
-            ),
-          ),
         ],
+      ),
+      bottomNavigationBar: Padding(
+        padding:
+        const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+        child: ElevatedButton(
+          onPressed: filter.isNotEmpty ? _onApplyFilter : null,
+          child: Text(
+            AppStrings.showFilterResults(filter.length),
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/screen/sight_search_screen.dart
+++ b/lib/ui/screen/sight_search_screen.dart
@@ -6,7 +6,6 @@ import 'package:places/domain/sight.dart';
 import 'package:places/service/utils.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_strings.dart';
-import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_details.dart';
 import 'package:places/ui/widget/controls/darken_image.dart';
@@ -87,14 +86,13 @@ class _SightSearchScreenState extends State<SightSearchScreen> {
 
               case SearchState.found:
                 return ListView.separated(
-                  physics: platformScrollPhysics,
                   itemCount: _filtered.length,
                   itemBuilder: (_, index) => _SightListTile(
                     sight: _filtered[index],
                   ),
                   separatorBuilder: (_, index) => const Divider(
                     height: 0.8,
-                    indent: 16 + 56 + 16,
+                    indent: 88,
                     endIndent: 16.0,
                   ),
                 );

--- a/lib/ui/screen/sight_search_screen.dart
+++ b/lib/ui/screen/sight_search_screen.dart
@@ -6,6 +6,7 @@ import 'package:places/domain/sight.dart';
 import 'package:places/service/utils.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_strings.dart';
+import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_details.dart';
 import 'package:places/ui/widget/controls/darken_image.dart';
@@ -36,7 +37,7 @@ class _SightSearchScreenState extends State<SightSearchScreen> {
   final _historyProvider = SearchHistoryProvider.createProvider();
   final _state = ValueNotifier<SearchState>(SearchState.initial);
   String? _lastSearch = '';
-  Iterable<Sight> _filtered = List.empty();
+  List<Sight> _filtered = List.empty();
 
   @override
   void initState() {
@@ -85,22 +86,16 @@ class _SightSearchScreenState extends State<SightSearchScreen> {
                 return const Loader();
 
               case SearchState.found:
-                final divider = Divider(
-                  height: 0.8,
-                  indent: 16 + 56 + 16,
-                  endIndent: 16.0,
-                  color: Theme.of(context).dividerColor,
-                );
-
-                // TODO(novikov): Напрашивается ListView.separated
-                return SingleChildScrollView(
-                  child: Column(
-                    children: _filtered
-                        .expand((sight) => [
-                              if (sight != _filtered.first) divider,
-                              _SightListTile(sight: sight),
-                            ])
-                        .toList(growable: false),
+                return ListView.separated(
+                  physics: platformScrollPhysics,
+                  itemCount: _filtered.length,
+                  itemBuilder: (_, index) => _SightListTile(
+                    sight: _filtered[index],
+                  ),
+                  separatorBuilder: (_, index) => const Divider(
+                    height: 0.8,
+                    indent: 16 + 56 + 16,
+                    endIndent: 16.0,
                   ),
                 );
 

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -44,7 +44,9 @@ class VisitingScreen extends StatelessWidget {
                 return TabBarView(
                   children: [
                     SightList(
-                      sights: data.where((sight) => !sight.isVisited),
+                      sights: data
+                          .where((sight) => !sight.isVisited)
+                          .toList(growable: false),
                       empty: const EmptyList(
                         icon: AppIcons.card,
                         title: AppStrings.empty,
@@ -55,7 +57,9 @@ class VisitingScreen extends StatelessWidget {
                           _onDragComplete(context, sourceId, insertAfterId),
                     ),
                     SightList(
-                      sights: data.where((sight) => sight.isVisited),
+                      sights: data
+                          .where((sight) => sight.isVisited)
+                          .toList(growable: false),
                       empty: const EmptyList(
                         icon: AppIcons.goRouteBig,
                         title: AppStrings.empty,

--- a/lib/ui/widget/add_sight_photos.dart
+++ b/lib/ui/widget/add_sight_photos.dart
@@ -9,7 +9,7 @@ import 'package:places/ui/widget/controls/svg_icon.dart';
 /// Виджет для управления фото при добавлении нового места.
 class AddSightPhotos extends StatefulWidget {
   final List<String>? initialValue;
-  final void Function(List<String>) onChange;
+  final ValueChanged<List<String>> onChange;
 
   const AddSightPhotos({
     Key? key,

--- a/lib/ui/widget/add_sight_photos.dart
+++ b/lib/ui/widget/add_sight_photos.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/mocks.dart';
 import 'package:places/ui/const/app_icons.dart';
-import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/widget/controls/spacers.dart';
 import 'package:places/ui/widget/controls/svg_icon.dart';
@@ -35,7 +34,6 @@ class _AddSightPhotosState extends State<AddSightPhotos> {
     return SizedBox(
       height: _cardSize,
       child: ListView(
-        physics: platformScrollPhysics,
         scrollDirection: Axis.horizontal,
         children: [
           _AddCard(onTap: _addPhoto),

--- a/lib/ui/widget/add_sight_photos.dart
+++ b/lib/ui/widget/add_sight_photos.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:places/mocks.dart';
 import 'package:places/ui/const/app_icons.dart';
+import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/widget/controls/spacers.dart';
 import 'package:places/ui/widget/controls/svg_icon.dart';
@@ -31,9 +32,11 @@ class _AddSightPhotosState extends State<AddSightPhotos> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
+    return SizedBox(
+      height: _cardSize,
+      child: ListView(
+        physics: platformScrollPhysics,
+        scrollDirection: Axis.horizontal,
         children: [
           _AddCard(onTap: _addPhoto),
           ...items.expand((element) => [

--- a/lib/ui/widget/search_history.dart
+++ b/lib/ui/widget/search_history.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:places/domain/search_history_provider.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_strings.dart';
-import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/widget/controls/loader.dart';
 import 'package:places/ui/widget/controls/spacers.dart';
@@ -66,7 +65,6 @@ class SearchHistory extends StatelessWidget {
                           maxHeight: constraints.maxHeight - 100.0,
                         ),
                         child: ListView.separated(
-                          physics: platformScrollPhysics,
                           shrinkWrap: true,
                           itemCount: items.length,
                           itemBuilder: (_, index) => ListTile(

--- a/lib/ui/widget/search_history.dart
+++ b/lib/ui/widget/search_history.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:places/domain/search_history_provider.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_strings.dart';
+import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/widget/controls/loader.dart';
 import 'package:places/ui/widget/controls/spacers.dart';
@@ -43,7 +44,8 @@ class SearchHistory extends StatelessWidget {
         return AnimatedBuilder(
           animation: historyProvider,
           builder: (context, child) {
-            if (snapshot.data!.isEmpty) {
+            final items = snapshot.data!.toList(growable: false);
+            if (items.isEmpty) {
               return const SizedBox();
             }
 
@@ -63,30 +65,28 @@ class SearchHistory extends StatelessWidget {
                         constraints: BoxConstraints(
                           maxHeight: constraints.maxHeight - 100.0,
                         ),
-                        // TODO(novikov): ListView.separated
-                        child: SingleChildScrollView(
-                          child: Column(
-                            children: ListTile.divideTiles(
-                              tiles: snapshot.data!.map((e) => ListTile(
-                                contentPadding: EdgeInsets.zero,
-                                title: Text(
-                                  e,
-                                  style: theme.text400Secondary2,
-                                ),
-                                trailing: IconButton(
-                                  splashRadius: 20.0,
-                                  icon: SvgIcon(
-                                    AppIcons.close,
-                                    color: closeColor,
-                                  ),
-                                  onPressed: () =>
-                                      historyProvider.remove(e),
-                                ),
-                                onTap: () => onItemTap(e),
-                              )),
-                              color: theme.dividerColor,
-                            ).toList(growable: false),
+                        child: ListView.separated(
+                          physics: platformScrollPhysics,
+                          shrinkWrap: true,
+                          itemCount: items.length,
+                          itemBuilder: (_, index) => ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(
+                              items[index],
+                              style: theme.text400Secondary2,
+                            ),
+                            trailing: IconButton(
+                              splashRadius: 20.0,
+                              icon: SvgIcon(
+                                AppIcons.close,
+                                color: closeColor,
+                              ),
+                              onPressed: () =>
+                                  historyProvider.remove(items[index]),
+                            ),
+                            onTap: () => onItemTap(items[index]),
                           ),
+                          separatorBuilder: (_, index) => const Divider(),
                         ),
                       ),
                       child!,

--- a/lib/ui/widget/sight_list.dart
+++ b/lib/ui/widget/sight_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
+import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_card.dart';
 import 'package:places/ui/screen/sight_list_screen.dart';
@@ -36,27 +37,17 @@ class SightList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final draggable = onOrderChanged != null && sights.length > 1;
-    // ListView.separated было бы логичней, но тогда приишлось бы тулить DragTarget в начале и конце списка
-    final count = sights.length * 2 + 1;
+    final count = sights.length;
 
     return sights.isEmpty
         ? empty
-        : ListView.builder(
-            itemCount: count,
-            itemBuilder: (_, virtualIndex) {
-              final index = virtualIndex ~/ 2;
-
-              // Четные - карточки
-              if (virtualIndex.isOdd) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: SightCard(sight: sights[index], mode: mode),
-                );
-              }
-
-              // Нечетные - разделители
-              final targetId =
-                  virtualIndex < count - 1 ? sights[index].id : null;
+        // Смысл itemBuilder и separatorBuilder инвертирован,
+        // чтобы поместить DragTarget в начало и конец списка
+        : ListView.separated(
+            physics: platformScrollPhysics,
+            itemCount: count + 1,
+            itemBuilder: (_, index) {
+              final targetId = index < count ? sights[index].id : null;
 
               return draggable
                   ? _DragTargetSpacer(
@@ -65,6 +56,10 @@ class SightList extends StatelessWidget {
                     )
                   : spacerH24;
             },
+            separatorBuilder: (_, index) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: SightCard(sight: sights[index], mode: mode),
+            ),
           );
   }
 }

--- a/lib/ui/widget/sight_list.dart
+++ b/lib/ui/widget/sight_list.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
-import 'package:places/ui/const/platform.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_card.dart';
 import 'package:places/ui/screen/sight_list_screen.dart';
@@ -44,7 +43,6 @@ class SightList extends StatelessWidget {
         // Смысл itemBuilder и separatorBuilder инвертирован,
         // чтобы поместить DragTarget в начало и конец списка
         : ListView.separated(
-            physics: platformScrollPhysics,
             itemCount: count + 1,
             itemBuilder: (_, index) {
               final targetId = index < count ? sights[index].id : null;

--- a/lib/ui/widget/sight_list.dart
+++ b/lib/ui/widget/sight_list.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
@@ -12,7 +11,7 @@ import 'package:places/ui/widget/controls/spacers.dart';
 /// Используется на экранах [SightListScreen] и [VisitingScreen].
 class SightList extends StatelessWidget {
   /// Список элементов для отображения.
-  final Iterable<Sight> sights;
+  final List<Sight> sights;
 
   /// Виджет, отображаемый в случае пустого списка элементов.
   final Widget empty;
@@ -37,42 +36,35 @@ class SightList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final draggable = onOrderChanged != null && sights.length > 1;
+    // ListView.separated было бы логичней, но тогда приишлось бы тулить DragTarget в начале и конце списка
+    final count = sights.length * 2 + 1;
 
     return sights.isEmpty
         ? empty
-        : SingleChildScrollView(
-            dragStartBehavior: DragStartBehavior.down,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  ...sights.expand(
-                    (sight) => [
-                      if (draggable)
-                        _DragTargetSpacer(
-                          id: sight.id,
-                          onOrderChanged: onOrderChanged,
-                        )
-                      else
-                        spacerH24,
-                      SightCard(
-                        key: ValueKey(sight.id),
-                        sight: sight,
-                        mode: mode,
-                      ),
-                    ],
-                  ),
-                  if (draggable)
-                    _DragTargetSpacer(
-                      id: null,
+        : ListView.builder(
+            itemCount: count,
+            itemBuilder: (_, virtualIndex) {
+              final index = virtualIndex ~/ 2;
+
+              // Четные - карточки
+              if (virtualIndex.isOdd) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: SightCard(sight: sights[index], mode: mode),
+                );
+              }
+
+              // Нечетные - разделители
+              final targetId =
+                  virtualIndex < count - 1 ? sights[index].id : null;
+
+              return draggable
+                  ? _DragTargetSpacer(
+                      id: targetId,
                       onOrderChanged: onOrderChanged,
                     )
-                  else
-                    spacerH24,
-                ],
-              ),
-            ),
+                  : spacerH24;
+            },
           );
   }
 }


### PR DESCRIPTION
В истории поиска ListView.separated выбран больших из-за удобства, чем из-за эффективности.

> Список фильтров на поисковом виджете

У меня там уже был GridView внутри Column, оставил их, но поправил верстку, чтобы в случае переполнения категорий появлялась прокрутка GridView.

https://user-images.githubusercontent.com/89590481/158341330-515619fb-1d5e-4b99-ae7a-cb0f838e636f.mp4


