### PR TITLE
Реализована адаптивная верстка экрана Фильтры

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,6 +6,7 @@ import 'package:places/domain/sight_repository.dart';
 import 'package:places/service/utils.dart';
 import 'package:places/ui/const/app_routes.dart';
 import 'package:places/ui/const/app_strings.dart';
+import 'package:places/ui/screen/res/responsive.dart';
 import 'package:places/ui/screen/res/themes.dart';
 import 'package:places/ui/widget/holders/favorites.dart';
 import 'package:places/ui/widget/holders/locations.dart';
@@ -48,6 +49,7 @@ class _AppState extends State<App> {
               locale: const Locale('ru'),
               initialRoute: AppRoutes.splash,
               routes: AppRoutes.routes,
+              builder: (_, child) => Responsive(child: child!),
             ),
           ),
         ),

--- a/lib/ui/screen/res/responsive.dart
+++ b/lib/ui/screen/res/responsive.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/material.dart';
+import 'package:places/ui/widget/holders/value_holder.dart';
+
+// ignore_for_file: prefer-single-widget-per-file
+
+/// Набор классов и виджетов для построения responsive UI.
+///
+/// [Responsive] - сохраняет responsive-информацию в дереве виджетов.
+/// [DeviceAdapter] - разделяет верстку по типам устройств.
+/// [HandsetAdapter] - разделяет верстку для телефонов с разным размером экрана.
+/// [TabletAdapter] - разделяет верстку для планшетов с разным размером экрана.
+/// [FontsSizeAdapter] - переопределяет размеры шрифтов текущей темы.
+
+/// Виджет для хранения responsive-информации в дереве виджетов.
+///
+/// Желательно хранить как можно ближе к корню, например:
+///
+///     return MaterialApp(
+///       builder: (_, child) => Responsive(child: child!),
+///     );
+class Responsive extends StatelessWidget {
+  final Widget child;
+
+  const Responsive({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return OrientationBuilder(
+      builder: (context, orientation) => ScreenInfo(
+        value: _ScreenInfo.from(context, orientation),
+        child: child,
+      ),
+    );
+  }
+
+  static _ScreenInfo? of(BuildContext context) =>
+      ValueHolder.of<ScreenInfo, _ScreenInfo>(context);
+}
+
+/// [DeviceAdapter] предоставляет набор билдеров для построения поддерева
+/// в зависимости от типа устройства:
+///   [DeviceType.handset] - телефон
+///   [DeviceType.tablet] - планшет
+///
+/// В комбмнации с [HandsetAdapter] и [TabletAdapter] позволяет
+/// максимально точно разделить верстку:
+///
+/// Например:
+///     return DeviceAdapter(
+///       handset: (_) => HandsetAdapter(
+///         small: (_) => ScreenSmallPhone(),
+///         orElse: (_) => ScreenAnyPhone(),
+///       ),
+///       tablet: (_) => ScreenAnyTablet(),
+///       orElse: (_) => ScreenLarge(),
+///     );
+///
+/// Данный код использует разную верстку для следующих групп устройств:
+///  - для телефонов с маленьким экраном
+///  - для телефонов со средним и большим экраном
+///  - для всех планшетов
+///  - для десктопов.
+class DeviceAdapter extends StatelessWidget {
+  final WidgetBuilder? handset;
+  final WidgetBuilder? tablet;
+  final WidgetBuilder? orElse;
+
+  const DeviceAdapter({
+    Key? key,
+    this.handset,
+    this.tablet,
+    this.orElse,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = ScreenInfo.of(context);
+    if (screen == null) {
+      return orElse!(context);
+    }
+
+    switch (screen.deviceType) {
+      case DeviceType.handset:
+        return handset != null ? handset!(context) : orElse!(context);
+
+      case DeviceType.tablet:
+        return tablet != null ? tablet!(context) : orElse!(context);
+
+      default:
+        return orElse!(context);
+    }
+  }
+}
+
+/// [HandsetAdapter] предоставляет набор билдеров для построения поддерева
+/// в зависимости от размера экрана телефона.
+///
+/// Например:
+///     return HandsetAdapter(
+///         small: (_) => ScreenSmallPhone(),
+///         orElse: (_) => ScreenUniversal(),
+///       );
+///
+///  Данный код использует отдельную верстку для телефонов с маленьким экраном.
+class HandsetAdapter extends StatelessWidget {
+  final WidgetBuilder? small;
+  final WidgetBuilder? medium;
+  final WidgetBuilder? large;
+  final WidgetBuilder? orElse;
+
+  const HandsetAdapter({
+    Key? key,
+    this.small,
+    this.medium,
+    this.large,
+    this.orElse,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = ScreenInfo.of(context);
+    if (screen == null || screen.deviceType != DeviceType.handset) {
+      return orElse!(context);
+    }
+
+    switch (screen.screenType) {
+      case ScreenType.small:
+        return small != null ? small!(context) : orElse!(context);
+
+      case ScreenType.medium:
+        return medium != null ? medium!(context) : orElse!(context);
+
+      case ScreenType.large:
+        return large != null ? large!(context) : orElse!(context);
+
+      default:
+        return orElse!(context);
+    }
+  }
+}
+
+/// [TabletAdapter] предоставляет набор билдеров для построения поддерева
+/// в зависимости от размера экрана планшета.
+///
+/// Например:
+///     return TabletAdapter(
+///         small: (_) => ScreenSmallTablet(),
+///         orElse: (_) => ScreenUniversal(),
+///       );
+///
+///  Данный код использует отдельную верстку для планшетов с маленьким экраном.
+class TabletAdapter extends StatelessWidget {
+  final WidgetBuilder? small;
+  final WidgetBuilder? large;
+  final WidgetBuilder? orElse;
+
+  const TabletAdapter({
+    Key? key,
+    this.small,
+    this.large,
+    this.orElse,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = ScreenInfo.of(context);
+    if (screen == null || screen.deviceType != DeviceType.tablet) {
+      return orElse!(context);
+    }
+
+    switch (screen.screenType) {
+      case ScreenType.small:
+        return small != null ? small!(context) : orElse!(context);
+
+      case ScreenType.large:
+        return large != null ? large!(context) : orElse!(context);
+
+      default:
+        return orElse!(context);
+    }
+  }
+}
+
+/// Адаптер размера шрифтов, используемых в теме.
+class FontsSizeAdapter extends StatefulWidget {
+  final Widget? child;
+  final WidgetBuilder? builder;
+  final double? delta;
+  final double? factor;
+
+  const FontsSizeAdapter({
+    Key? key,
+    this.child,
+    this.builder,
+    this.delta,
+    this.factor,
+  })  : assert(child != null || builder != null, 'child or builder expected'),
+        assert((child == null) != (builder == null),
+            'only child or builder allowed'),
+        super(key: key);
+
+  @override
+  State<FontsSizeAdapter> createState() => _FontsSizeAdapterState();
+}
+
+class _FontsSizeAdapterState extends State<FontsSizeAdapter> {
+  ThemeData? _themeData;
+
+  @override
+  void didChangeDependencies() {
+    final needAdapt = widget.factor != null || widget.delta != null;
+
+    if (needAdapt) {
+      final theme = Theme.of(context);
+
+      final fontSizeFactor = widget.factor ?? 1.0;
+      final fontSizeDelta = widget.delta ?? 0.0;
+
+      _themeData = theme.copyWith(
+        textTheme: theme.textTheme.apply(
+          fontSizeFactor: fontSizeFactor,
+          fontSizeDelta: fontSizeDelta,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: theme.elevatedButtonTheme.style?.copyWith(
+            textStyle: theme.elevatedButtonTheme.style?.textStyle?.apply(
+              fontSizeFactor: fontSizeFactor,
+              fontSizeDelta: fontSizeDelta,
+            ),
+          ),
+        ),
+        // TODO(novikov): адаптировать все текстовые элементы темы
+      );
+    } else {
+      _themeData = null;
+    }
+
+    super.didChangeDependencies();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final child =
+        widget.child != null ? widget.child! : widget.builder!(context);
+
+    return _themeData != null
+        ? Theme(
+            data: _themeData!,
+            child: child,
+          )
+        : child;
+  }
+}
+
+extension on MaterialStateProperty<TextStyle?> {
+  MaterialStateProperty<TextStyle?> apply({
+    required double fontSizeFactor,
+    required double fontSizeDelta,
+  }) =>
+      MaterialStateProperty.all(resolve({})?.apply(
+        fontSizeFactor: fontSizeFactor,
+        fontSizeDelta: fontSizeDelta,
+      ));
+}
+
+/// Обеспечивает хранение экземпляра [_ScreenInfo] в дереве виджетов.
+class ScreenInfo extends ValueHolder<_ScreenInfo> {
+  const ScreenInfo({
+    Key? key,
+    required _ScreenInfo value,
+    required Widget child,
+  }) : super(
+          key: key,
+          value: value,
+          child: child,
+        );
+
+  static _ScreenInfo? of(BuildContext context) =>
+      ValueHolder.of<ScreenInfo, _ScreenInfo>(context);
+}
+
+/// Информация о размерах экрна усттройства.
+class _ScreenInfo {
+  final DeviceType deviceType;
+  final ScreenType screenType;
+  final bool isPortrait;
+
+  _ScreenInfo({
+    required this.deviceType,
+    required this.screenType,
+    required this.isPortrait,
+  });
+
+  factory _ScreenInfo.from(BuildContext context, Orientation orientation) {
+    final mediaQuery = MediaQuery.of(context);
+    final width = mediaQuery.size.shortestSide;
+
+    // https://material.io/archive/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints
+    var device = DeviceType.desktop;
+    var screen = ScreenType.large;
+
+    if (width <= 600) {
+      device = DeviceType.handset;
+      if (width <= 360) {
+        screen = ScreenType.small;
+      } else if (width <= 400) {
+        screen = ScreenType.medium;
+      }
+    } else if (width <= 960) {
+      device = DeviceType.tablet;
+      if (width <= 720) {
+        screen = ScreenType.small;
+      }
+    }
+
+    return _ScreenInfo(
+      deviceType: device,
+      screenType: screen,
+      isPortrait: orientation == Orientation.portrait,
+    );
+  }
+}
+
+/// Тип устройства.
+enum DeviceType { handset, tablet, desktop }
+
+/// Тип размера экрана.
+enum ScreenType { small, medium, large }

--- a/lib/ui/screen/res/themes.dart
+++ b/lib/ui/screen/res/themes.dart
@@ -2,91 +2,101 @@ import 'package:flutter/material.dart';
 import 'package:places/ui/const/app_styles.dart';
 import 'package:places/ui/const/dark_colors.dart';
 import 'package:places/ui/const/light_colors.dart';
+import 'package:places/ui/screen/res/theme_extension.dart';
 
 abstract class Themes {
   /// Светлая тема.
-  static ThemeData get light => ThemeData.from(
-        colorScheme: _buildColorScheme(isLight: true),
-        textTheme: _buildTextTheme(),
-      ).copyWith(
-        appBarTheme: _buildAppBarTheme(
-          background: LightColors.background,
-          title: LightColors.main,
-          leading: LightColors.secondary2,
-          trailing: LightColors.green,
-        ),
-        tabBarTheme: _buildTabBarTheme(
-          tabBackground: LightColors.secondary,
-          labelColor: LightColors.white,
-          unselectedLabelColor: LightColors.inactiveBlack,
-        ),
-        cardTheme: _buildCardTheme(),
-        iconTheme: _buildIconTheme(color: LightColors.white),
-        elevatedButtonTheme: _buildElevatedButtonThemeData(isLight: true),
-        textButtonTheme: _buildTextButtonThemeData(
-          active: LightColors.secondary,
-          inactive: LightColors.inactiveBlack,
-        ),
-        sliderTheme: _buildSliderThemeData(
-          active: LightColors.green,
-          inactive: LightColors.inactiveBlack,
-          thumb: LightColors.white,
-        ),
-        inputDecorationTheme: _buildInputDecorationTheme(isLight: true),
-        textSelectionTheme:
-            _buildTextSelectionThemeData(color: LightColors.green),
-        listTileTheme: _buildListTileThemeData(color: LightColors.main),
-        dividerColor: LightColors.inactiveBlack.withOpacity(0.24),
-        dividerTheme: _buildDividerThemeData(
-          color: LightColors.inactiveBlack.withOpacity(0.24),
-        ),
-        bottomNavigationBarTheme: _buildBottomNavigationBarTheme(
-          background: LightColors.background,
-          foreground: DarkColors.secondary,
-        ),
-      );
+  static ThemeData get light {
+    final theme = ThemeData.from(
+      colorScheme: _buildColorScheme(isLight: true),
+      textTheme: _buildTextTheme(),
+    );
+
+    // TODO(novikov): Оптимизировать по аналогии с _buildElevatedButtonThemeData
+
+    return theme.copyWith(
+      appBarTheme: _buildAppBarTheme(
+        background: LightColors.background,
+        title: LightColors.main,
+        leading: LightColors.secondary2,
+        trailing: LightColors.green,
+      ),
+      tabBarTheme: _buildTabBarTheme(
+        tabBackground: LightColors.secondary,
+        labelColor: LightColors.white,
+        unselectedLabelColor: LightColors.inactiveBlack,
+      ),
+      cardTheme: _buildCardTheme(),
+      iconTheme: _buildIconTheme(color: LightColors.white),
+      elevatedButtonTheme: _buildElevatedButtonThemeData(theme),
+      textButtonTheme: _buildTextButtonThemeData(
+        active: LightColors.secondary,
+        inactive: LightColors.inactiveBlack,
+      ),
+      sliderTheme: _buildSliderThemeData(
+        active: LightColors.green,
+        inactive: LightColors.inactiveBlack,
+        thumb: LightColors.white,
+      ),
+      inputDecorationTheme: _buildInputDecorationTheme(isLight: true),
+      textSelectionTheme:
+          _buildTextSelectionThemeData(color: LightColors.green),
+      listTileTheme: _buildListTileThemeData(color: LightColors.main),
+      dividerColor: LightColors.inactiveBlack.withOpacity(0.24),
+      dividerTheme: _buildDividerThemeData(
+        color: LightColors.inactiveBlack.withOpacity(0.24),
+      ),
+      bottomNavigationBarTheme: _buildBottomNavigationBarTheme(
+        background: LightColors.background,
+        foreground: DarkColors.secondary,
+      ),
+    );
+  }
 
   /// Темная тема.
-  static ThemeData get dark => ThemeData.from(
-        colorScheme: _buildColorScheme(isLight: false),
-        textTheme: _buildTextTheme(),
-      ).copyWith(
-        appBarTheme: _buildAppBarTheme(
-          background: DarkColors.background,
-          title: DarkColors.white,
-          leading: DarkColors.secondary2,
-          trailing: DarkColors.green,
-        ),
-        tabBarTheme: _buildTabBarTheme(
-          tabBackground: DarkColors.white,
-          labelColor: DarkColors.secondary,
-          unselectedLabelColor: DarkColors.secondary2,
-        ),
-        cardTheme: _buildCardTheme(),
-        iconTheme: _buildIconTheme(color: DarkColors.white),
-        elevatedButtonTheme: _buildElevatedButtonThemeData(isLight: false),
-        textButtonTheme: _buildTextButtonThemeData(
-          active: DarkColors.white,
-          inactive: DarkColors.inactiveBlack,
-        ),
-        sliderTheme: _buildSliderThemeData(
-          active: DarkColors.green,
-          inactive: DarkColors.inactiveBlack,
-          thumb: DarkColors.white,
-        ),
-        inputDecorationTheme: _buildInputDecorationTheme(isLight: false),
-        textSelectionTheme:
-            _buildTextSelectionThemeData(color: DarkColors.green),
-        listTileTheme: _buildListTileThemeData(color: DarkColors.white),
-        dividerColor: DarkColors.inactiveBlack.withOpacity(0.24),
-        dividerTheme: _buildDividerThemeData(
-          color: DarkColors.inactiveBlack.withOpacity(0.24),
-        ),
-        bottomNavigationBarTheme: _buildBottomNavigationBarTheme(
-          background: DarkColors.background,
-          foreground: DarkColors.white,
-        ),
-      );
+  static ThemeData get dark {
+    final theme = ThemeData.from(
+      colorScheme: _buildColorScheme(isLight: false),
+      textTheme: _buildTextTheme(),
+    );
+
+    return theme.copyWith(
+      appBarTheme: _buildAppBarTheme(
+        background: DarkColors.background,
+        title: DarkColors.white,
+        leading: DarkColors.secondary2,
+        trailing: DarkColors.green,
+      ),
+      tabBarTheme: _buildTabBarTheme(
+        tabBackground: DarkColors.white,
+        labelColor: DarkColors.secondary,
+        unselectedLabelColor: DarkColors.secondary2,
+      ),
+      cardTheme: _buildCardTheme(),
+      iconTheme: _buildIconTheme(color: DarkColors.white),
+      elevatedButtonTheme: _buildElevatedButtonThemeData(theme),
+      textButtonTheme: _buildTextButtonThemeData(
+        active: DarkColors.white,
+        inactive: DarkColors.inactiveBlack,
+      ),
+      sliderTheme: _buildSliderThemeData(
+        active: DarkColors.green,
+        inactive: DarkColors.inactiveBlack,
+        thumb: DarkColors.white,
+      ),
+      inputDecorationTheme: _buildInputDecorationTheme(isLight: false),
+      textSelectionTheme: _buildTextSelectionThemeData(color: DarkColors.green),
+      listTileTheme: _buildListTileThemeData(color: DarkColors.white),
+      dividerColor: DarkColors.inactiveBlack.withOpacity(0.24),
+      dividerTheme: _buildDividerThemeData(
+        color: DarkColors.inactiveBlack.withOpacity(0.24),
+      ),
+      bottomNavigationBarTheme: _buildBottomNavigationBarTheme(
+        background: DarkColors.background,
+        foreground: DarkColors.white,
+      ),
+    );
+  }
 
   /// Тема для строки поиска SearchBar.
   static ThemeData searchBarTheme({required bool isLight}) {
@@ -175,21 +185,19 @@ abstract class Themes {
       );
 
   /// ElevatedButton.
-  static ElevatedButtonThemeData _buildElevatedButtonThemeData({
-    required bool isLight,
-  }) {
-    final background = isLight ? LightColors.green : DarkColors.green;
-    final foreground = isLight ? LightColors.white : DarkColors.white;
-    final disabledBackground =
-        isLight ? LightColors.cardBackground : DarkColors.cardBackground;
-    final disabledForeground =
-        isLight ? LightColors.inactiveBlack : DarkColors.inactiveBlack;
+  static ElevatedButtonThemeData _buildElevatedButtonThemeData(
+    ThemeData theme,
+  ) {
+    final background = theme.colorScheme.green;
+    final foreground = theme.colorScheme.white;
+    final disabledBackground = theme.colorScheme.surface;
+    final disabledForeground = theme.colorScheme.inactiveBlack;
 
     return ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         primary: background,
         onPrimary: foreground,
-        textStyle: button,
+        textStyle: theme.textTheme.button,
         padding: const EdgeInsets.all(15.0),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(

--- a/lib/ui/widget/holders/favorites.dart
+++ b/lib/ui/widget/holders/favorites.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:places/domain/favorites_provider.dart';
 import 'package:places/ui/widget/holders/value_holder.dart';
 


### PR DESCRIPTION
1. По [градации](https://material.io/archive/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints) MaterialDesign (хоть и архивной), 480x800 - это большой экран, поэтому в качестве подопытного взял 360x640dp.
2. В responsive.dart увлекся чуть больше, чем требовало задание. Принципиально не смотрел, что есть на пабе на эту тему - пока, по возможности, стараюсь изобретать свои велосипеды.
3. Для горизонтальной прокрутки категорий используется GridView с одной строкой, а не ListView - так проще 
формировать общий для обеих версток список категорий.
4. Кнопку подтягивать вверх не стал (хотя в дизайне она подтянута).

![9-2-3-responsive](https://user-images.githubusercontent.com/89590481/160302064-8d0e5740-ca45-469b-99b1-dc292bf1ef8b.png)


