### PR TITLE
Реализована обработка сетевых ошибок

### DIFF
--- a/lib/data/rest/dio_rest_client.dart
+++ b/lib/data/rest/dio_rest_client.dart
@@ -154,7 +154,7 @@ class DioRestClient implements RestClient {
     dynamic data,
   }) async {
     try {
-      return _dio.request<dynamic>(
+      return await dio.request<dynamic>(
         path,
         queryParameters: params,
         data: data,
@@ -202,6 +202,9 @@ class DioRestClient implements RestClient {
     if (error is SocketException) {
       if (error.message.contains('Connection refused')) {
         throw ConnectionRefusedException();
+      }
+      if (error.message.contains('Failed host lookup')) {
+        throw FailedHostLookupException();
       }
     }
   }

--- a/lib/data/rest/rest_exception.dart
+++ b/lib/data/rest/rest_exception.dart
@@ -23,6 +23,8 @@ class RequestCanceledException extends RestException {}
 
 class ConnectionRefusedException extends RestException {}
 
+class FailedHostLookupException extends RestException {}
+
 /// Ошибки сервера.
 class ServerException extends RestException {}
 

--- a/lib/ui/const/app_strings.dart
+++ b/lib/ui/const/app_strings.dart
@@ -57,14 +57,26 @@ abstract class AppStrings {
   static const enterNumber = 'Введите число';
   static const notChosen = 'Не выбрано';
   static const search = 'Поиск';
-  static const error = 'Ошибка';
-  static const tryLater = 'Что-то пошло не так,\nпопробуйте позже';
   static const nothingFound = 'Ничего не найдено';
   static const tryAnotherSearch = 'Попробуйте изменить параметры поиска';
   static const errorOnInit  = 'Ошибка инициализации';
   static const errorOnInitDesc  = 'Попробуйте очистить кэш и перезапустить приложение';
   static const scheduleDate = 'Запланировать посещение';
   static const rescheduleDate = 'Перепланировать посещение';
+
+  // Ошибки
+  static const error = 'Ошибка';
+  static const unknownError = 'Что-то пошло не так, $tryLater';
+  static const tryLater = 'попробуйте позже';
+  static const connectTimeout = 'Нет связи с сервером, $tryLater';
+  static const sendTimeout = 'Не удалось выполнить запрос, $tryLater';
+  static const receiveTimeout = 'Сервер не отвечает, $tryLater';
+  static const requestCanceled  = 'Запрос отменен';
+  static const connectionRefused = 'Сервер временно недоступен, $tryLater';
+  static const failedHostLookup = 'Проверьте подключение к Интернету';
+  static const srvInvalidRequest = 'Сервер сообщает об ошибке';
+  static const srvDuplicate = 'Объект уже сущестует';
+  static const srvNotFound = 'Объект не найден';
 
   // Экран Избранное
   static const alreadyVisited = 'Уже посетил';

--- a/lib/ui/const/errors.dart
+++ b/lib/ui/const/errors.dart
@@ -1,0 +1,39 @@
+import 'package:places/data/rest/rest_exception.dart';
+import 'package:places/ui/const/app_strings.dart';
+
+/// Человекочитаемые описания ошибок.
+abstract class Errors {
+  static String humanReadableText(Object error) {
+    if (error is String) {
+      return error;
+    }
+    if (error is Exception) {
+      return error.humanReadableText;
+    }
+
+    return AppStrings.unknownError;
+  }
+}
+
+extension ExceptionExt on Exception {
+  static const _errors = <Type, String>{
+    // Ошибки связи
+    ConnectTimeoutException: AppStrings.connectTimeout,
+    SendTimeoutException: AppStrings.sendTimeout,
+    ReceiveTimeoutException: AppStrings.receiveTimeout,
+    RequestCanceledException: AppStrings.requestCanceled,
+    ConnectionRefusedException: AppStrings.connectionRefused,
+    FailedHostLookupException: AppStrings.failedHostLookup,
+    // Ошибки сервера
+    SrvInvalidRequestException: AppStrings.srvInvalidRequest,
+    SrvDuplicateException: AppStrings.srvDuplicate,
+    SrvNotFoundException: AppStrings.srvNotFound,
+  };
+
+  String get humanReadableText =>
+      _errors[runtimeType] ?? AppStrings.unknownError;
+
+  bool get isKnown => this is RestException;
+
+  bool get isUnknown => !isKnown;
+}

--- a/lib/ui/screen/add_sight_screen.dart
+++ b/lib/ui/screen/add_sight_screen.dart
@@ -4,7 +4,10 @@ import 'package:places/domain/sight.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_strings.dart';
 import 'package:places/ui/const/categories.dart';
+import 'package:places/ui/const/errors.dart';
 import 'package:places/ui/screen/list_picker.dart';
+import 'package:places/ui/screen/res/logger.dart';
+import 'package:places/ui/screen/res/scaffold_messenger_extension.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/widget/add_sight_photos.dart';
 import 'package:places/ui/widget/controls/loader.dart';
@@ -223,12 +226,8 @@ class _AddSightScreenState extends State<AddSightScreen> {
         await context.placeInteractor.addNew(sight: _data.toSight());
         navigator.pop(true);
       } on Exception catch (e, stacktrace) {
-        debugPrint('$e, $stacktrace');
-        scaffoldMessenger.showSnackBar(
-          const SnackBar(
-            content: Text(AppStrings.tryLater),
-          ),
-        );
+        logErrorIfUnknown(e, stacktrace);
+        scaffoldMessenger.showError(e.humanReadableText);
       } finally {
         _inProcess(false);
       }

--- a/lib/ui/screen/res/logger.dart
+++ b/lib/ui/screen/res/logger.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+import 'package:places/ui/const/errors.dart';
+
+void logErrorIfUnknown(Exception error, StackTrace stacktrace) {
+  if (error.isUnknown) {
+    debugPrint('$error\n$stacktrace');
+  }
+}

--- a/lib/ui/screen/res/scaffold_messenger_extension.dart
+++ b/lib/ui/screen/res/scaffold_messenger_extension.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+extension ScaffoldMessengerExtension on ScaffoldMessengerState {
+  void showError(String message) {
+    final theme = Theme.of(context);
+
+    showSnackBar(SnackBar(
+      content: Text(
+        message,
+        style: theme.textTheme.bodyText1?.copyWith(
+          color: theme.colorScheme.onError,
+        ),
+      ),
+      backgroundColor: theme.colorScheme.error,
+    ));
+  }
+}

--- a/lib/ui/screen/sight_details.dart
+++ b/lib/ui/screen/sight_details.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_strings.dart';
+import 'package:places/ui/const/errors.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_card.dart';
 import 'package:places/ui/widget/controls/darken_image.dart';
@@ -42,10 +43,10 @@ class _SightDetailsState extends State<SightDetails> {
         future: _load,
         builder: (context, snapshot) {
           if (snapshot.hasError) {
-            return const EmptyList(
+            return EmptyList(
               icon: AppIcons.error,
               title: AppStrings.error,
-              details: AppStrings.tryLater,
+              details: Errors.humanReadableText(snapshot.error!),
             );
           }
           if (snapshot.hasData) {

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -7,6 +7,7 @@ import 'package:places/domain/sight.dart';
 import 'package:places/ui/const/app_icons.dart';
 import 'package:places/ui/const/app_routes.dart';
 import 'package:places/ui/const/app_strings.dart';
+import 'package:places/ui/const/errors.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_card.dart';
 import 'package:places/ui/widget/controls/gradient_fab.dart';
@@ -99,13 +100,11 @@ class _SightListScreenState extends State<SightListScreen> {
 
             /// Ошибка.
             errorBuilder: (_, error, stacktrace) {
-              return const SliverFillRemaining(
-                child: Center(
-                  child: EmptyList(
-                    icon: AppIcons.error,
-                    title: AppStrings.error,
-                    details: AppStrings.tryLater,
-                  ),
+              return SliverFillRemaining(
+                child: EmptyList(
+                  icon: AppIcons.error,
+                  title: AppStrings.error,
+                  details: Errors.humanReadableText(error),
                 ),
               );
             },

--- a/lib/ui/widget/empty_list.dart
+++ b/lib/ui/widget/empty_list.dart
@@ -29,42 +29,37 @@ class EmptyList extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    Widget body = FractionallySizedBox(
-      widthFactor: 0.7,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          SvgPicture.asset(
-            icon,
-            width: 64.0,
-            height: 64.0,
-            color: theme.colorScheme.inactiveBlack,
-          ),
-          spacerH24,
-          Text(
-            title,
-            textAlign: TextAlign.center,
-            style: theme.subtitleInactiveBlack,
-          ),
-          if (details != null) ...[
-            spacerH8,
-            Text(
-              details!,
-              textAlign: TextAlign.center,
-              style: theme.smallInactiveBlack,
+    return Container(
+      width: double.infinity,
+      padding: padding,
+      child: FractionallySizedBox(
+        widthFactor: 0.7,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SvgPicture.asset(
+              icon,
+              width: 64.0,
+              height: 64.0,
+              color: theme.colorScheme.inactiveBlack,
             ),
+            spacerH24,
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: theme.subtitleInactiveBlack,
+            ),
+            if (details != null) ...[
+              spacerH8,
+              Text(
+                details!,
+                textAlign: TextAlign.center,
+                style: theme.smallInactiveBlack,
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
-
-    if (padding != null) {
-      body = Padding(
-        padding: padding!,
-        child: body,
-      );
-    }
-
-    return body;
   }
 }

--- a/lib/ui/widget/sight_card_image.dart
+++ b/lib/ui/widget/sight_card_image.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/ui/const/app_icons.dart';
-import 'package:places/ui/const/app_strings.dart';
 import 'package:places/ui/const/categories.dart';
+import 'package:places/ui/const/errors.dart';
+import 'package:places/ui/screen/res/logger.dart';
+import 'package:places/ui/screen/res/scaffold_messenger_extension.dart';
 import 'package:places/ui/screen/res/theme_extension.dart';
 import 'package:places/ui/screen/sight_card.dart';
 import 'package:places/ui/screen/visiting_screen.dart';
@@ -96,12 +98,8 @@ class SightCardImage extends StatelessWidget {
           ? favoritesNotifier.trigger()
           : sightHolder.value = newSight;
     } on Exception catch (e, stacktrace) {
-      debugPrint('$e, $stacktrace');
-      scaffoldMessenger.showSnackBar(
-        const SnackBar(
-          content: Text(AppStrings.tryLater),
-        ),
-      );
+      logErrorIfUnknown(e, stacktrace);
+      scaffoldMessenger.showError(e.humanReadableText);
     }
   }
 
@@ -121,12 +119,8 @@ class SightCardImage extends StatelessWidget {
       await placeInteractor.schedule(sight: sight, planned: plannedDate);
       sightNotifier.value = sight.copyWith(plannedDate: plannedDate);
     } on Exception catch (e, stacktrace) {
-      debugPrint('$e, $stacktrace');
-      scaffoldMessenger.showSnackBar(
-        const SnackBar(
-          content: Text(AppStrings.tryLater),
-        ),
-      );
+      logErrorIfUnknown(e, stacktrace);
+      scaffoldMessenger.showError(e.humanReadableText);
     }
   }
 }


### PR DESCRIPTION
Немного отошел от ТЗ:
- Кастомные исключения уже были - не стал переименовывать
- Ошибки уже выводились в лог на уровне REST-клиента, не стал дублировать в UI-слое
- Не стал переопределять toString
- Добавил snackBar с ошибкой там, где посчитал, что она нужна, а поноэкранный вариант неуместен.

Задумка была в том, чтобы показывать пользователю чуть более подробную информацию об ошибке.
Но т.к. ошибки могут возникать на разных уровнях, задействовать toString для этого нельзя, поэтому конвертация исключения в строку вынесена в UI-слой.
Разделил ошибки на известные и неизвестные: соответственно пользователю показывается либо конкретное описание, либо общая фраза. Неизвестные дополнительно логируются в UI-слое вместе со stacktrace'ом.

Примеры логирования сетевых ошибок на уровне REST-клиента:
```
>> GET /place/-1
<< GET /place/-1 - Not Found (404)
DioError [DioErrorType.response]: Http status error [404]

GET /place/173
GET /place/173 - ERROR
DioError [DioErrorType.other]: SocketException: Failed host lookup: 'test-backend-flutter.surfstudio.ru' (OS Error: No address associated with hostname, errno = 7)

```

Видео результата:

https://user-images.githubusercontent.com/89590481/163641944-127ed7c4-86f3-4d84-8858-9b2de658ab73.mp4


P.S. Ошибся в названии ветки, должна быть 12.